### PR TITLE
Updated Linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 SublimeLinter-contrib-codeclimate
 =================================
 
-> Please note: This was originally a fork of [codeclimate/SublimeLinter-contrib-codeclimate][codeclimate-origin] to make it compatible for SublimeLinter 4.
-
 [![Build Status](https://travis-ci.org/codeclimate/SublimeLinter-contrib-codeclimate.svg?branch=master)](https://travis-ci.org/codeclimate/SublimeLinter-contrib-codeclimate)
 
 This linter plugin for [SublimeLinter][docs] provides an interface to [codeclimate](https://github.com/codeclimate/codeclimate). Code Climate supports a variety of languages through standardized Docker images known as static analysis engines.
@@ -27,37 +25,28 @@ Within Sublime Text, bring up the [Command Palette][cmd] and type `install`. Amo
 
 When the plugin list appears, type `codeclimate`. Among the entries you should see `SublimeLinter-contrib-codeclimate`. If that entry is not highlighted, use the keyboard or mouse to select it.
 
-## Settings
-For general information on how SublimeLinter works with settings, please see [Settings][settings]. For information on generic linter settings, please see [Linter Settings][linter-settings].
-
 ## How it works
-
-The linter is first looking for a SublimeText Project. If a `*.sublime-project` is given, it executes `codeclimate` in the project root directory. If no project is given, it tries to execute `codeclimate` in the first opened folder of the folder pane.
+The linter is first looking for a SublimeText Project. If a `*.sublime-project` is given, it executes `codeclimate` in the directory of the project root. If no project is given, it tries to execute `codeclimate` in the first opened folder of the folder pane. If just a file is open, it tries to execute `codeclimate` in the file directory.
 
 If the SublimeText project folder or the first opened folder in the folder pane contains a `.codeclimate.yml` configuration file, `codeclimate` will recognise its settings. If no configuration file can be evaluated, `codeclimate` will automatically run the defaults of `structure` and `duplication` at this time.
 
-## Linter Configuration
+## Settings
+For general information on how SublimeLinter works with settings, please see [Settings][settings]. For information on generic linter settings, please see [Linter Settings][linter-settings].
 
-To specify the path to executable, please use the SublimeLinter settings:
+### Examples
+You can set the path to the `codeclimate` executable in the global SublimeLinter settings or your project settings:
 
 ```json
 {
   "linters": {
-    "executable": "/usr/local/bin/codeclimate"
+    "codeclimate": {
+      "executable": "/usr/local/bin/codeclimate"
+    }
   }
 }
 ```
 
-
-If your `.codeclimate.yml` does not live in the project root folder, you can set also the `working_dir` of SublimeLinter:
-
-```json
-{
-  "working_dir": "${folder:$file_path}"
-}
-```
-
-If you want to ignore the configuration in a `.codeclimate.yml`, for instance, to run a subset of codeclimate engines, you can configure this by setting the linter arguments either in the global SublimeLinter settings or in your project settings. In the global settings, this could look like this:
+If you want to ignore the configuration of a `.codeclimate.yml`,  for instance, to run a subset of codeclimate engines, you can set linter arguments  in the global SublimeLinter settings or your project settings:
 
 ```json
 {
@@ -71,6 +60,14 @@ If you want to ignore the configuration in a `.codeclimate.yml`, for instance, t
         ]
     }
   }
+}
+```
+
+It is also possible to set a working directory for execution. But be careful with this! To make this work with the `codeclimate` CLI, the working directory ***must*** be in the path of the file you want to lint!
+
+```json
+{
+  "working_dir": "/path/to/working/dir"
 }
 ```
 
@@ -92,7 +89,6 @@ Please note that modifications should follow these coding guidelines:
 
 Thank you for helping out!
 
-[codeclimate-origin]: https://github.com/codeclimate/SublimeLinter-contrib-codeclimate
 [docs]: http://sublimelinter.readthedocs.org
 [installation]: http://sublimelinter.readthedocs.org/en/latest/installation.html
 [locating-executables]: http://sublimelinter.readthedocs.org/en/latest/usage.html#how-linter-executables-are-located

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 SublimeLinter-contrib-codeclimate
-================================
+=================================
+
+> Please note: This was originally a fork of [codeclimate/SublimeLinter-contrib-codeclimate][codeclimate-origin] to make it compatible for SublimeLinter 4.
 
 [![Build Status](https://travis-ci.org/codeclimate/SublimeLinter-contrib-codeclimate.svg?branch=master)](https://travis-ci.org/codeclimate/SublimeLinter-contrib-codeclimate)
 
 This linter plugin for [SublimeLinter][docs] provides an interface to [codeclimate](https://github.com/codeclimate/codeclimate). Code Climate supports a variety of languages through standardized Docker images known as static analysis engines.
 
 ## Installation
-SublimeLinter 3 must be installed in order to use this plugin. If SublimeLinter 3 is not installed, please follow the instructions [here][installation].
+SublimeLinter 4 must be installed in order to use this plugin. If SublimeLinter 4 is not installed, please follow the instructions [here][installation].
 
 ### Linter installation
 Before using this plugin, you must ensure that `codeclimate` is installed on your system. Please see the `codeclimate` documentation, specifically [Prerequisites](https://github.com/codeclimate/codeclimate#prerequisites) and [Installation](https://github.com/codeclimate/codeclimate#installation)
 
 ### Linter configuration
-In order for `codeclimate` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. Before going any further, please read and follow the steps in [“Finding a linter executable”](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable) through “Validating your PATH” in the documentation.
-
-__This plugin requires usage within a Sublime project at this time.__
+In order for `codeclimate` to be executed by SublimeLinter, you must ensure that its path is available to SublimeLinter. Before going any further, please read and follow the steps in ["Finding a linter executable"](http://sublimelinter.readthedocs.org/en/latest/troubleshooting.html#finding-a-linter-executable) through "Validating your PATH" in the documentation.
 
 Once you have installed and configured `codeclimate`, you can proceed to install the SublimeLinter-contrib-codeclimate plugin if it is not yet installed.
 
@@ -23,21 +23,48 @@ Please use [Package Control][pc] to install the linter plugin. This will ensure 
 
 To install via Package Control, do the following:
 
-1. Within Sublime Text, bring up the [Command Palette][cmd] and type `install`. Among the commands you should see `Package Control: Install Package`. If that command is not highlighted, use the keyboard or mouse to select it. There will be a pause of a few seconds while Package Control fetches the list of available plugins.
+Within Sublime Text, bring up the [Command Palette][cmd] and type `install`. Among the commands you should see `Package Control: Install Package`. If that command is not highlighted, use the keyboard or mouse to select it. There will be a pause of a few seconds while Package Control fetches the list of available plugins.
 
-1. When the plugin list appears, type `codeclimate`. Among the entries you should see `SublimeLinter-contrib-codeclimate`. If that entry is not highlighted, use the keyboard or mouse to select it.
+When the plugin list appears, type `codeclimate`. Among the entries you should see `SublimeLinter-contrib-codeclimate`. If that entry is not highlighted, use the keyboard or mouse to select it.
 
 ## Settings
 For general information on how SublimeLinter works with settings, please see [Settings][settings]. For information on generic linter settings, please see [Linter Settings][linter-settings].
+
+## How it works
+
+The linter is first looking for a SublimeText Project. If a `*.sublime-project` is given, it executes `codeclimate` in the project root directory. If no project is given, it tries to execute `codeclimate` in the first opened folder of the folder pane.
+
+If the SublimeText project folder or the first opened folder in the folder pane contains a `.codeclimate.yml` configuration file, `codeclimate` will recognise its settings. If no configuration file can be evaluated, `codeclimate` will automatically run the defaults of `structure` and `duplication` at this time.
+
+## Linter Configuration
+
+To specify the path to executable, please use the SublimeLinter settings:
+
+```json
+{
+  "linters": {
+    "executable": "/usr/local/bin/codeclimate"
+  }
+}
+```
+
+
+If your `.codeclimate.yml` does not live in the project root folder, you can set also the `working_dir` of SublimeLinter:
+
+```json
+{
+  "working_dir": "${folder:$file_path}"
+}
+```
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 
 1. Fork the plugin repository.
-1. Hack on a separate topic branch created from the latest `master`.
-1. Commit and push the topic branch.
-1. Make a pull request.
-1. Be patient.  ;-)
+2. Hack on a separate topic branch created from the latest `master`.
+3. Commit and push the topic branch.
+4. Make a pull request.
+5. Be patient.
 
 Please note that modifications should follow these coding guidelines:
 
@@ -48,6 +75,7 @@ Please note that modifications should follow these coding guidelines:
 
 Thank you for helping out!
 
+[codeclimate-origin]: https://github.com/codeclimate/SublimeLinter-contrib-codeclimate
 [docs]: http://sublimelinter.readthedocs.org
 [installation]: http://sublimelinter.readthedocs.org/en/latest/installation.html
 [locating-executables]: http://sublimelinter.readthedocs.org/en/latest/usage.html#how-linter-executables-are-located

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Within Sublime Text, bring up the [Command Palette][cmd] and type `install`. Amo
 When the plugin list appears, type `codeclimate`. Among the entries you should see `SublimeLinter-contrib-codeclimate`. If that entry is not highlighted, use the keyboard or mouse to select it.
 
 ## How it works
-The linter is first looking for a SublimeText Project. If a `*.sublime-project` is given, it executes `codeclimate` in the directory of the project root. If no project is given, it tries to execute `codeclimate` in the first opened folder of the folder pane. If just a file is open, it tries to execute `codeclimate` in the file directory.
+If the first opened folder in SublimeText contains a `.codeclimate.yml` configuration file in its root, `codeclimate` will recognize this file's settings.
 
-If the SublimeText project folder or the first opened folder in the folder pane contains a `.codeclimate.yml` configuration file, `codeclimate` will recognise its settings. If no configuration file can be evaluated, `codeclimate` will automatically run the defaults of `structure` and `duplication` at this time.
+Suppose the `codeclimate` CLI finds no configuration file in the folder root: In that case, it will automatically run the default inspections of `structure` and `duplication`. If you have a `.codeclimate.yml` configuration file in a different folder, you can set SublimeLinter's `working_dir` setting (please see examples).
 
 ## Settings
 For general information on how SublimeLinter works with settings, please see [Settings][settings]. For information on generic linter settings, please see [Linter Settings][linter-settings].
@@ -46,7 +46,7 @@ You can set the path to the `codeclimate` executable in the global SublimeLinter
 }
 ```
 
-If you want to ignore the configuration of a `.codeclimate.yml`,  for instance, to run a subset of codeclimate engines, you can set linter arguments  in the global SublimeLinter settings or your project settings:
+If you want to ignore the configuration of a `.codeclimate.yml`,  for instance, to run a subset of codeclimate engines, you can set linter arguments in the global SublimeLinter settings or your project settings:
 
 ```json
 {
@@ -63,13 +63,21 @@ If you want to ignore the configuration of a `.codeclimate.yml`,  for instance, 
 }
 ```
 
-It is also possible to set a working directory for execution. But be careful with this! To make this work with the `codeclimate` CLI, the working directory ***must*** be in the path of the file you want to lint!
+Suppose you use a `.codeclimate.yml`-configuration file. In that case, the `codeclimate` CLI needs to be executed in your configuration file's directory. Otherwise, it can't detect your configuration and runs only the default analyzes.
+
+SublimeLinter takes the (first) open folder (or the folder of a single opened file) as the working directory for executing its linter commands. You can change this behavior by setting the working directory of execution:
 
 ```json
 {
-  "working_dir": "/path/to/working/dir"
+  "linters": {
+    "codeclimate": {
+      "working_dir": "/path/to/working/dir"
+    }
+  }
 }
 ```
+
+*Hint: Make sure the working directory is in the path of the file you want to lint!*
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Within Sublime Text, bring up the [Command Palette][cmd] and type `install`. Amo
 When the plugin list appears, type `codeclimate`. Among the entries you should see `SublimeLinter-contrib-codeclimate`. If that entry is not highlighted, use the keyboard or mouse to select it.
 
 ## How it works
-If the first opened folder in SublimeText contains a `.codeclimate.yml` configuration file in its root, `codeclimate` will recognize this file's settings.
+If the opened folder in SublimeText contains a `.codeclimate.yml` configuration file in its root, `codeclimate` will recognize this file's settings.
 
 Suppose the `codeclimate` CLI finds no configuration file in the folder root: In that case, it will automatically run the default inspections of `structure` and `duplication`. If you have a `.codeclimate.yml` configuration file in a different folder, you can set SublimeLinter's `working_dir` setting (please see examples).
 
@@ -65,7 +65,7 @@ If you want to ignore the configuration of a `.codeclimate.yml`,  for instance, 
 
 Suppose you use a `.codeclimate.yml`-configuration file. In that case, the `codeclimate` CLI needs to be executed in your configuration file's directory. Otherwise, it can't detect your configuration and runs only the default analyzes.
 
-SublimeLinter takes the (first) open folder (or the folder of a single opened file) as the working directory for executing its linter commands. You can change this behavior by setting the working directory of execution:
+SublimeLinter takes the current file's root folder in SublimeText's sidebar as the working directory for executing its linter commands. You can change this behavior by setting the working directory of execution:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ If your `.codeclimate.yml` does not live in the project root folder, you can set
 }
 ```
 
+If you want to ignore the configuration in a `.codeclimate.yml`, for instance, to run a subset of codeclimate engines, you can configure this by setting the linter arguments either in the global SublimeLinter settings or in your project settings. In the global settings, this could look like this:
+
+```json
+{
+  "linters": {
+    "codeclimate": {
+      "args": [
+          "-e",
+          "structure",
+          "-e",
+          "duplication"
+        ]
+    }
+  }
+}
+```
+
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 

--- a/linter.py
+++ b/linter.py
@@ -25,7 +25,7 @@ class Codeclimate(Linter):
         'selector': (
             'source.css, '
             'source.go, '
-            'source.haskall, '
+            'source.haskell, '
             'source.java, '
             'source.javascript, '
             'source.js, '

--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,6 @@ from SublimeLinter.lint import Linter, PermanentError, util
 class Codeclimate(Linter):
     """Provides an interface to codeclimate."""
     defaults = {
-        'excludes': ['!${folder::}*'],
         'selector': (
             'source.css, '
             'source.go, '

--- a/linter.py
+++ b/linter.py
@@ -34,8 +34,8 @@ class Codeclimate(Linter):
         )
     }
 
-    regex = r'^== ((?P<filename>.*)(?= \(\d+ issue\) ==))( \(\d+ issue\) ==\n(?P<line>\d+))(?:-\d+)?:\s(?P<message>.+)$'
-    multiline = True
+    regex = r'^(?P<line>\d+)(?:-\d+)?:\s(?P<message>.+)$'
+    multiline = False
     line_col_base = (1, 1)
     tempfile_suffix = '-'
     error_stream = util.STREAM_BOTH

--- a/linter.py
+++ b/linter.py
@@ -1,16 +1,18 @@
 #
 # linter.py
-# Linter for SublimeLinter3, a code checking framework for Sublime Text 3
+# Linter for SublimeLinter4, a code checking framework for Sublime Text 3
 #
 # Written by Noah Davis
 # Copyright (c) 2016 Noah Davis
 #
+# Updated by Schuyler Jager & Andreas for SublimeLinter 4
+# Copyright (c) 2020 Schuyler Jager & Andreas
 # License: MIT
 #
 
 """This module exports the Codeclimate plugin class."""
 
-from SublimeLinter.lint import Linter, util, persist
+from SublimeLinter.lint import Linter, util
 
 
 class Codeclimate(Linter):
@@ -42,14 +44,7 @@ class Codeclimate(Linter):
     word_re = None
 
     def cmd(self):
-        """Construct a cmd to provide a relative path to 'codeclimate analyze'."""
-        result = ['codeclimate', 'analyze', '-e', 'structure', '-e', 'duplication']
-        relative_file_name = None
-        for folder in self.view.window().folders():
-            if self.filename.find(folder) == 0:
-                relative_file_name = self.filename.replace(folder + '/', '')
-        if relative_file_name == None:
-            return result
-        result.append(relative_file_name)
-        persist.debug(result)
-        return result
+        """Set working directory and run 'codeclimate analyze'."""
+        if self.context.get('project_root') is None:
+            self.defaults['chdir'] = '${folder}'
+        return ['codeclimate', 'analyze', '${file_on_disk}']

--- a/linter.py
+++ b/linter.py
@@ -44,9 +44,6 @@ class Codeclimate(Linter):
     error_stream = util.STREAM_BOTH
     word_re = None
 
-    root = None
-    path = None
-
     def cmd(self):
         """Set working directory and run 'codeclimate analyze'."""
         if self.context.get('project_root') is None:

--- a/linter.py
+++ b/linter.py
@@ -11,17 +11,12 @@
 #
 
 """This module exports the Codeclimate plugin class."""
-
-import re
 from SublimeLinter.lint import Linter, util
 
 
 class Codeclimate(Linter):
     """Provides an interface to codeclimate."""
-
     defaults = {
-        'chdir': "${project}",
-        'executable': 'codeclimate',
         'selector': (
             'source.css, '
             'source.go, '
@@ -45,12 +40,10 @@ class Codeclimate(Linter):
     word_re = None
 
     def cmd(self):
-        """Set working directory and run 'codeclimate analyze'."""
-        if self.context.get('project_root') is None:
-            self.defaults['chdir'] = '${folder}' \
-                if self.context.get('folder') is not None \
-                else '${file_path}'
+        """Set command and run 'codeclimate analyze'."""
+        if 'executable' in self.settings:
+            command = self.settings.get('executable')
+        else:
+            command = 'codeclimate'
 
-        root = re.search(r"\{(\w+)\}", self.defaults['chdir']).group(1)
-        path = self.filename.replace(self.context.get(root) + '/', '')
-        return ['codeclimate', 'analyze', path]
+        return [command, 'analyze', '${args}', '${file}']

--- a/linter.py
+++ b/linter.py
@@ -46,5 +46,7 @@ class Codeclimate(Linter):
     def cmd(self):
         """Set working directory and run 'codeclimate analyze'."""
         if self.context.get('project_root') is None:
-            self.defaults['chdir'] = '${folder}'
+            self.defaults['chdir'] = '${folder}' \
+                if self.context.get('folder') is not None \
+                else '${file_path}'
         return ['codeclimate', 'analyze', '${file_on_disk}']

--- a/linter.py
+++ b/linter.py
@@ -11,8 +11,12 @@
 #
 
 """This module exports the Codeclimate plugin class."""
+import logging
 import os
 from SublimeLinter.lint import Linter, PermanentError, util
+
+
+logger = logging.getLogger('SublimeLinter.plugin.codeclimate')
 
 
 class Codeclimate(Linter):
@@ -46,13 +50,14 @@ class Codeclimate(Linter):
         abs_path = self.filename
         working_dir = self.get_working_dir()
 
-        msg = 'The file \'%s\' is not part of the working dir (%s). ' \
-              'Please see the Linter\'s README.md to get further ' \
-              'instructions.' % (abs_path, working_dir)
+        msg = 'The file \'%s\' is not part of any open folder in ' \
+              'SublimeText. Please see the Linter\'s README.md to ' \
+              'get further instructions.' % (abs_path)
 
         if not (abs_path.startswith(os.path.abspath(working_dir) + os.sep)):
+            logger.warning(msg)
             self.notify_unassign()
-            raise PermanentError(msg)
+            raise PermanentError('File not part of an open folder in SublimeText.')
 
         file = os.path.relpath(abs_path, working_dir)
         return ['codeclimate', 'analyze', '${args}', file, '${xoo}']

--- a/linter.py
+++ b/linter.py
@@ -12,6 +12,7 @@
 
 """This module exports the Codeclimate plugin class."""
 
+import re
 from SublimeLinter.lint import Linter, util
 
 
@@ -43,10 +44,16 @@ class Codeclimate(Linter):
     error_stream = util.STREAM_BOTH
     word_re = None
 
+    root = None
+    path = None
+
     def cmd(self):
         """Set working directory and run 'codeclimate analyze'."""
         if self.context.get('project_root') is None:
             self.defaults['chdir'] = '${folder}' \
                 if self.context.get('folder') is not None \
                 else '${file_path}'
-        return ['codeclimate', 'analyze', '${file_on_disk}']
+
+        root = re.search(r"\{(\w+)\}", self.defaults['chdir']).group(1)
+        path = self.filename.replace(self.context.get(root) + '/', '')
+        return ['codeclimate', 'analyze', path]

--- a/linter.py
+++ b/linter.py
@@ -18,6 +18,7 @@ from SublimeLinter.lint import Linter, PermanentError, util
 class Codeclimate(Linter):
     """Provides an interface to codeclimate."""
     defaults = {
+        'excludes': ['!${folder::}*'],
         'selector': (
             'source.css, '
             'source.go, '
@@ -33,6 +34,7 @@ class Codeclimate(Linter):
             'text.html'
         )
     }
+
     regex = r'^== ((?P<filename>.*)(?= \(\d+ issue\) ==))( \(\d+ issue\) ==\n(?P<line>\d+))(?:-\d+)?:\s(?P<message>.+)$'
     multiline = True
     line_col_base = (1, 1)

--- a/linter.py
+++ b/linter.py
@@ -33,8 +33,8 @@ class Codeclimate(Linter):
             'text.html'
         )
     }
-    regex = r'^(?P<line>\d+)(?:-\d+)?:\s(?P<message>.+)$'
-    multiline = False
+    regex = r'^== ((?P<filename>.*)(?= \(\d+ issue\) ==))( \(\d+ issue\) ==\n(?P<line>\d+))(?:-\d+)?:\s(?P<message>.+)$'
+    multiline = True
     line_col_base = (1, 1)
     tempfile_suffix = '-'
     error_stream = util.STREAM_BOTH

--- a/linter.py
+++ b/linter.py
@@ -11,12 +11,8 @@
 #
 
 """This module exports the Codeclimate plugin class."""
-import logging
 import os
-from SublimeLinter.lint import Linter, util
-
-
-logger = logging.getLogger('SublimeLinter.plugin.eslint')
+from SublimeLinter.lint import Linter, PermanentError, util
 
 
 class Codeclimate(Linter):
@@ -49,24 +45,13 @@ class Codeclimate(Linter):
         abs_path = self.filename
         working_dir = self.get_working_dir()
 
-        msg = 'You try to lint the file %s from outside of SublimeText\'s ' \
-              'working directory (%s), which is not supported by this ' \
-              'SublimeLinter plugin at this time. You can do either:\n' \
-              '* You open the directory containing the current file in' \
-              'a new window. You may have to add a customized ' \
-              '`.codeclimate.yml` configuration to that directory ' \
-              'as well;\n' \
-              '* You change the working directory of the linter plugin in ' \
-              ' the global or the Project\'s settings;\n' \
-              '* You disable the linter plugin in the global or the ' \
-              'Project\'s settings.\n\n' \
-              'Please visit https://github.com/codeclimate/' \
-              'SublimeLinter-contrib-codeclimate for examples.' \
-              '\n' % (abs_path, working_dir)
+        msg = 'The file \'%s\' is not part of the working dir (%s). ' \
+              'Please see the Linter\'s README.md to get further ' \
+              'instructions.' % (abs_path, working_dir)
 
         if not (abs_path.startswith(os.path.abspath(working_dir) + os.sep)):
-            logger.info(msg)
-            return None
+            self.notify_unassign()
+            raise PermanentError(msg)
 
         file = os.path.relpath(abs_path, working_dir)
         return ['codeclimate', 'analyze', '${args}', file, '${xoo}']

--- a/linter.py
+++ b/linter.py
@@ -64,13 +64,9 @@ class Codeclimate(Linter):
               'SublimeLinter-contrib-codeclimate for examples.' \
               '\n' % (abs_path, working_dir)
 
-        command = ['codeclimate', 'analyze', '${args}']
-
         if not (abs_path.startswith(os.path.abspath(working_dir) + os.sep)):
             logger.info(msg)
             return None
 
-        file = os.path.relpath(self.filename, self.get_working_dir())
-        command.append(file)
-        command.append('${xoo}')
-        return command
+        file = os.path.relpath(abs_path, working_dir)
+        return ['codeclimate', 'analyze', '${args}', file, '${xoo}']


### PR DESCRIPTION
Hi @schuylr 

Thank you very much for your pull request (#2) at the codeclimate repository. As far as I can see, the repository is indeed abandoned, as you already mentioned.

I've updated the linter class to get rid of the "file_on_disk" warning and the attribute error of "persist.debug(result)"

"file_on_disk" warning:

```
WARNING: codeclimate: Implicit appending a filename to `cmd` has been deprecated, 
add '${file_on_disk}' explicitly.
```

attribute error of "persist.debug(result)":

```
File "~/Library/Application Support/Sublime Text 3/Packages/SublimeLinter-contrib-
codeclimate/linter.py", line 54, in cmd
    persist.debug(result)
AttributeError: 'module' object has no attribute 'debug'
```

Further on – as far as I understand the `codeclimate cli`, it is not necessary to set the "structure" and "duplication" in `'codeclimate', 'analyze', '-e', 'structure', '-e', 'duplication'`. The `codeclimeate cli` runs these two by default when no `.codeclimate.yml` configuration is given, e.g. for linter.py:

```
codeclimate analyze linter.py                                                          
Starting analysis                                                                                             
Running structure: Done!                                                                                      
Running duplication: Done!
```

I plan to bring the updated linter to package control. However, it is my first SublimeLinter implementation. I wonder what you think? Does the linter work as expected with my changes, or do you notice regressions?

I would be pleased to hear from you.

PS: My next steps are preparing a new travis ci and do a PR to the SublimeLinter repo.

